### PR TITLE
fix glitches in attachments list

### DIFF
--- a/app/assets/javascripts/ffcrm_attachments/custom.js
+++ b/app/assets/javascripts/ffcrm_attachments/custom.js
@@ -102,22 +102,25 @@ function file_size_in_bytes(limit_size) {
   return value;
 }
 
-function get_file_input(file_attr_name) {
-  file_name_div = "<div class='current_file_name'></div>";
-  file_size_div = "<div class='file_size'></div>";
-  remove_link_div = "<div class='remove_link'><a href='#'>Remove</a></div>";
-  file_input_div = "<input id='attach' name='"+file_attr_name+"' type='file'>";
-  complete_div = "<div class='attach_div'>" + file_input_div + file_name_div +
-    file_size_div + remove_link_div + "</div>";
-  return complete_div;
+function get_file_input(file_attr_name, descriptionName) {
+  var fileInfo = '<span class="current_file_info"> <span class="file_size"></span> </span>';
+  var remove_link_div = "<span class='remove_link'><a href='#'>Remove</a></span>";
+  var file_input_div = '<input class="attach" name="' + file_attr_name + '" type="file">';
+  var descriptionField = '<input type="text" class="file-description" placeholder="Description" style="display:none" name="'
+      + descriptionName
+      + '">';
+  return '<li class="attach_div">' + file_input_div + fileInfo + descriptionField + remove_link_div + '</li>';
 }
 
 function append_file_input(last_file_input) {
   if(last_file_input.length > 0) {
     var input_length = $("#entity_extra").find('input:file').length;
+    // get the correct parameters for attachment and its description and adapt it for multiple attachments
     var attr_name = $('input.attach').attr('name');
     var set_attr_name = attr_name.replace("[0]", "["+input_length+"]");
-    var next_attach_input = get_file_input(set_attr_name);
+    var descriptionName = $('input.file-description').prop('name');
+    var newDescriptionName = descriptionName.replace('[0]', "[" + input_length + "]");
+    var next_attach_input = get_file_input(set_attr_name, newDescriptionName);
     $(".next_attachment").append(next_attach_input);
   }
 }

--- a/app/assets/javascripts/ffcrm_attachments/custom.js
+++ b/app/assets/javascripts/ffcrm_attachments/custom.js
@@ -40,6 +40,7 @@ $(document).on('change', '.attach', function (){
     var file_size = get_file_size(this.files[0]);
     parent_div.find(".file_size").html(file_size);
 
+    parent_div.find(".file-description").show();
     // display remove attachment link
     parent_div.find(".remove_link").show();
   }

--- a/app/assets/javascripts/ffcrm_attachments/custom.js
+++ b/app/assets/javascripts/ffcrm_attachments/custom.js
@@ -14,9 +14,9 @@ $(document).on("click", "#main form[class^=new_] input[type=submit], #main form[
   return false;
 });
 
-$(document).on('change', "#attach", function (){
-  var parent_div = $(this).closest(".attach_div");
-  var attach_limit = $(parent_div.closest('table')[0]).attr("attach_limit");
+$(document).on('change', '.attach', function (){
+  var parent_div = $(this).closest('.attach_div');
+  var attach_limit = $(parent_div.closest('ul')[0]).attr('attach_limit');
   var attach_limit_size = file_size_in_bytes(attach_limit);
   var file_type = this.files[0].type;
 
@@ -27,7 +27,7 @@ $(document).on('change', "#attach", function (){
     parent_div.find(".file_size").html('');
     parent_div.find(".remove_link").hide();
   } else {
-    var last_file_input = $("#entity_extra").find('input').last()[0].files;
+    var last_file_input = $("#entity_extra").find('input.attach').last()[0].files;
 
     // append file input
     append_file_input(last_file_input);
@@ -49,7 +49,7 @@ $(document).on('click', ".remove_link", function(){
   // new attachment
   var $this = $(this);
   current_file_div = $this.closest(".attach_div");
-  current_file_div.find("#attach").val('');
+  current_file_div.find('.attach').val('');
   current_file_div.hide();
 
   // old attachment
@@ -59,7 +59,7 @@ $(document).on('click', ".remove_link", function(){
 });
 
 function destroy_attachment(current_file_div, current_obj) {
-  edit_form = current_obj.closest('table').hasClass('edit_form');
+  edit_form = current_obj.closest('ul').hasClass('edit_form');
   old_attachment = current_obj.hasClass('display_remove');
 
   if(edit_form && old_attachment) {
@@ -114,7 +114,7 @@ function get_file_input(file_attr_name) {
 function append_file_input(last_file_input) {
   if(last_file_input.length > 0) {
     var input_length = $("#entity_extra").find('input:file').length;
-    var attr_name = $("input#attach").attr('name');
+    var attr_name = $('input.attach').attr('name');
     var set_attr_name = attr_name.replace("[0]", "["+input_length+"]");
     var next_attach_input = get_file_input(set_attr_name);
     $(".next_attachment").append(next_attach_input);

--- a/app/assets/stylesheets/ffcrm_attachments/custom.css
+++ b/app/assets/stylesheets/ffcrm_attachments/custom.css
@@ -15,27 +15,24 @@
   margin-bottom: 2%;
 }
 
-#attach {
-  width: 17% !important;
-  display: inline;
+.attach {
+  list-style-type: none;
 }
 
 .attach_div {
-  width: 500px;
-  display: block;
+  width: 90%;
+}
+
+.current_file_info {
+  font-size: 13px;
 }
 
 .file_size {
-  display: inline-block;
   font-size: 13px;
   line-height: 22px;
-  margin-left: 58%;
-  vertical-align: bottom;
 }
 
 .current_file_name {
-  display: inline;
-  position: absolute;
   font-size: 13px;
   margin-left: 10px;
   margin-top: 8px;
@@ -43,7 +40,6 @@
 }
 
 .remove_link {
-  float: right;
   display: none;
   font-size: 13px;
   margin-left: 10px;

--- a/app/assets/stylesheets/ffcrm_attachments/custom.css
+++ b/app/assets/stylesheets/ffcrm_attachments/custom.css
@@ -21,10 +21,21 @@
 
 .attach_div {
   width: 90%;
+  vertical-align: middle; /* match to .section input. Should affect all elements in the div */
+}
+
+input.attach{
+  margin-top:0;
+}
+
+input.file-description {
+  margin-top: 0;
+  vertical-align: inherit;
 }
 
 .current_file_info {
   font-size: 13px;
+  vertical-align: inherit;
 }
 
 .file_size {
@@ -35,7 +46,6 @@
 .current_file_name {
   font-size: 13px;
   margin-left: 10px;
-  margin-top: 8px;
   width: 27%;
 }
 
@@ -44,6 +54,7 @@
   font-size: 13px;
   margin-left: 10px;
   margin-top: 8px;
+  vertical-align: inherit;
 }
 
 .display_remove {

--- a/app/views/attachments/_attachments.html.haml
+++ b/app/views/attachments/_attachments.html.haml
@@ -12,3 +12,4 @@
                 .attach_block
                   = link_to attachment_preview(attach), download_attachment_path(attach), {title: attach.attachment_file_name}
                   .file_name= file_name(attach)
+                  .attachment-description= attach.description

--- a/app/views/attachments/_attachments_new.html.haml
+++ b/app/views/attachments/_attachments_new.html.haml
@@ -13,8 +13,8 @@
           - new_record = t.object.new_record?
           = t.file_field 'attachment', class: 'attach'
           %span.current_file_info
-            %span.current_file_name= t.object.try(:attachment_file_name)
             - unless new_record
+              %span.current_file_name= t.object.try(:attachment_file_name)
               %span -
               %i= t.object.try :description
               %span.file_size

--- a/app/views/attachments/_attachments_new.html.haml
+++ b/app/views/attachments/_attachments_new.html.haml
@@ -7,19 +7,16 @@
 
 .section
   #entity_extra{ hidden_if(collapsed) }
-    %table{class: edit ? "edit_form" : "", 'attach_limit' => attach_limit_size }
-      %tr
-        %td
-          = f.simple_fields_for :attachments do |t|
-            .attach_div
-              - new_record = t.object.new_record?
+    %ul{class: edit ? 'edit_form' : '', 'attach_limit' => attach_limit_size }
+      = f.simple_fields_for :attachments do |t|
+        %li.attach_div
+          - new_record = t.object.new_record?
+          = t.file_field 'attachment', class: 'attach'
+          %span.current_file_info
+            %span.current_file_name= t.object.try(:attachment_file_name)
+            - unless new_record
+              %span.file_size
+                = "(#{number_to_human_size(t.object.try(:attachment_file_size))})"
+          %span.remove_link{class: new_record ? '' : 'display_remove'}= link_to t('delete', default: 'remove'), '#', data: new_record ? {} : { confirm: 'Are you sure want to delete this attachment?' }
 
-              = t.file_field 'attachment', id: 'attach'
-
-              .current_file_name= t.object.try(:attachment_file_name)
-
-              .file_size= number_to_human_size(t.object.try(:attachment_file_size)) unless new_record
-
-              .remove_link{class: new_record ? "" : "display_remove"}= link_to 'Remove', '#', confirm: new_record ? false : "Are you sure want to delete this attachment?"
-
-          .next_attachment
+      .next_attachment

--- a/app/views/attachments/_attachments_new.html.haml
+++ b/app/views/attachments/_attachments_new.html.haml
@@ -15,8 +15,12 @@
           %span.current_file_info
             %span.current_file_name= t.object.try(:attachment_file_name)
             - unless new_record
+              %span -
+              %i= t.object.try :description
               %span.file_size
                 = "(#{number_to_human_size(t.object.try(:attachment_file_size))})"
+            %span.file_size
+          = t.text_field :description, class: 'file-description', placeholder: t('description', default: 'Description').upcase, style: 'display: none;'
           %span.remove_link{class: new_record ? '' : 'display_remove'}= link_to t('delete', default: 'remove'), '#', data: new_record ? {} : { confirm: 'Are you sure want to delete this attachment?' }
 
       .next_attachment

--- a/config/locales/de_ffcrm_attachments.yml
+++ b/config/locales/de_ffcrm_attachments.yml
@@ -1,3 +1,4 @@
 ---
 de:
   extra_doc: Dokumente
+  description: Beschreibung

--- a/config/locales/en-US_ffcrm_attachments.yml
+++ b/config/locales/en-US_ffcrm_attachments.yml
@@ -1,3 +1,4 @@
 ---
 en-US:
   extra_doc: Documents
+  description: Description

--- a/db/migrate/20161130120341_add_description_to_attachments.rb
+++ b/db/migrate/20161130120341_add_description_to_attachments.rb
@@ -1,0 +1,9 @@
+class AddDescriptionToAttachments < ActiveRecord::Migration
+  def self.up
+    add_column :attachments, :description, :text, default: nil
+  end
+
+  def self.down
+    remove_column :attachments, :description
+  end
+end


### PR DESCRIPTION
This changes the layout of the attachments list (in edit) to an `<ul>` instead of table and removes or changes unnecessary fixed width sizes