### PR TITLE
change style of attachment list: one row per attachment

### DIFF
--- a/app/assets/stylesheets/ffcrm_attachments/custom.css
+++ b/app/assets/stylesheets/ffcrm_attachments/custom.css
@@ -10,11 +10,6 @@
   margin-top: 2%;
 }
 
-.attach_block {
-  display: inline-block;
-  margin-bottom: 2%;
-}
-
 .attach {
   list-style-type: none;
 }
@@ -61,10 +56,25 @@ input.file-description {
   display: inline;
 }
 
-.section #entity_extra table {
-  width: 100%;
-}
-
 .error {
   color: red;
+}
+
+/**
+ * Styles for the attachments list
+ */
+table.attachments {
+  width: 70%;
+}
+
+td.attachment-preview {
+  width: 10%;
+}
+
+td.attachment-file-name {
+  width: 30%;
+}
+
+td.attachment-description {
+  width: 60%;
 }

--- a/app/views/attachments/_attachments.html.haml
+++ b/app/views/attachments/_attachments.html.haml
@@ -4,12 +4,13 @@
   = subtitle :entity_attachments, collapsed, t(:extra_doc) + " (#{entity.attachments.count})"
   .attachments
     #entity_attachments{ hidden_if(collapsed) }
-      %table
-        %tr
-          %td
-            - if entity.attachments.present?
-              - entity.attachments.each do |attach|
-                .attach_block
-                  = link_to attachment_preview(attach), download_attachment_path(attach), {title: attach.attachment_file_name}
-                  .file_name= file_name(attach)
-                  .attachment-description= attach.description
+      - if entity.attachments.present?
+        %table.attachments
+          - entity.attachments.each do |attach|
+            %tr
+              %td.attachment-preview
+                = link_to attachment_preview(attach), download_attachment_path(attach), {title: attach.attachment_file_name}
+              %td.attachment-file-name
+                = attach.attachment_file_name.truncate(50)
+              %td.attachment-description
+                = attach.description


### PR DESCRIPTION
This changes the style of the attachment list for an entity.

The description is added and each attachment gets one row.