### PR TITLE
Localize Strings in JavaScript

### DIFF
--- a/app/assets/javascripts/ffcrm_attachments/custom.js
+++ b/app/assets/javascripts/ffcrm_attachments/custom.js
@@ -104,9 +104,9 @@ function file_size_in_bytes(limit_size) {
 
 function get_file_input(file_attr_name, descriptionName) {
   var fileInfo = '<span class="current_file_info"> <span class="file_size"></span> </span>';
-  var remove_link_div = "<span class='remove_link'><a href='#'>Remove</a></span>";
+  var remove_link_div = "<span class='remove_link'><a href='#'>" + I18nForAttachments.delete + "</a></span>";
   var file_input_div = '<input class="attach" name="' + file_attr_name + '" type="file">';
-  var descriptionField = '<input type="text" class="file-description" placeholder="Description" style="display:none" name="'
+  var descriptionField = '<input type="text" class="file-description" placeholder="' + I18nForAttachments.description.toUpperCase() + '" style="display:none" name="'
       + descriptionName
       + '">';
   return '<li class="attach_div">' + file_input_div + fileInfo + descriptionField + remove_link_div + '</li>';

--- a/app/assets/javascripts/ffcrm_attachments/custom.js
+++ b/app/assets/javascripts/ffcrm_attachments/custom.js
@@ -21,10 +21,9 @@ $(document).on('change', '.attach', function (){
   var file_type = this.files[0].type;
 
   if((file_type == "") || (this.files[0].size > attach_limit_size)) {
-    error_msg = (file_type == "") ? "Invalid file type" : "File size is too long.";
-    parent_div.find('.current_file_name').addClass('error').html(error_msg);
+    var error_msg = (file_type == "") ? I18nForAttachments.invalid_file_type : I18nForAttachments.file_too_big;
+    parent_div.find('.current_file_info').addClass('error').html(error_msg);
     $(this).val('');
-    parent_div.find(".file_size").html('');
     parent_div.find(".remove_link").hide();
   } else {
     var last_file_input = $("#entity_extra").find('input.attach').last()[0].files;

--- a/app/helpers/attachment_helper.rb
+++ b/app/helpers/attachment_helper.rb
@@ -11,4 +11,9 @@ module AttachmentHelper
   def file_name(attachment)
     attachment.attachment_file_name.truncate(20)
   end
+
+  def current_translations # copied from http://stackoverflow.com/a/10610347/1796645
+    @translations ||= I18n.backend.send(:translations)
+    @translations[I18n.locale].with_indifferent_access
+  end
 end

--- a/app/views/attachments/_attachments_new.html.haml
+++ b/app/views/attachments/_attachments_new.html.haml
@@ -1,3 +1,6 @@
+-# get Rails locales (copied from http://stackoverflow.com/a/10610347/1796645). Complicated Name to avoid possible conflicts with other gems
+:javascript
+  window.I18nForAttachments = #{(current_translations.to_json.html_safe)};
 - attach_limit_size = Setting.attachment_size || 2.megabytes
 - edit = !f.object.new_record?
 - collapsed = session[:entity_extra].nil?
@@ -22,6 +25,6 @@
                 = "(#{number_to_human_size(t.object.try(:attachment_file_size))})"
             %span.file_size
           = t.text_field :description, class: 'file-description', placeholder: t('description', default: 'Description').upcase, style: 'display: none;'
-          %span.remove_link{class: old_record ? 'display_remove'  : ''}= link_to t('delete', default: 'remove'), '#', data: old_record ? { confirm: 'Are you sure want to delete this attachment?' } : {}
+          %span.remove_link{class: old_record ? 'display_remove'  : ''}= link_to t('delete', default: 'Remove'), '#', data: old_record ? { confirm: 'Are you sure want to delete this attachment?' } : {}
 
       .next_attachment

--- a/config/locales/de_ffcrm_attachments.yml
+++ b/config/locales/de_ffcrm_attachments.yml
@@ -2,3 +2,5 @@
 de:
   extra_doc: Dokumente
   description: Beschreibung
+  invalid_file_type: Unerlaubter Dateityp
+  file_too_big: Datei ist zu groß.

--- a/config/locales/en-US_ffcrm_attachments.yml
+++ b/config/locales/en-US_ffcrm_attachments.yml
@@ -2,3 +2,5 @@
 en-US:
   extra_doc: Documents
   description: Description
+  invalid_file_type: Invalid file type
+  file_too_big: File size is too big.


### PR DESCRIPTION
This adds localized strings to the UI elements that are generated with JavaScript.
It also fixes the display of error messages.

# Test Plan

## without error

1. Set locale to `de`
2. Open Entity Edit form
3. Add two attachmets
4. Expected: both rows show _Beschreibung_ and _Löschen_

## with error

1. Set locale to `de`
2. Open Entity Edit form
3. Add attachment with file size over 10MB (or whatever is set in settings)
4. Expected: Message _Datei ist zu groß._