### PR TITLE
allow non-admin users to download attachments

### DIFF
--- a/lib/ffcrm_attachments/ability.rb
+++ b/lib/ffcrm_attachments/ability.rb
@@ -1,0 +1,12 @@
+module FfcrmAttachments
+  module Ability
+    def initialize(user)
+      super
+
+      if user.present?
+        # Attachment
+        can :download, Attachment
+      end
+    end
+  end
+end

--- a/lib/ffcrm_attachments/engine.rb
+++ b/lib/ffcrm_attachments/engine.rb
@@ -2,11 +2,11 @@ module FfcrmAttachments
   class Engine < ::Rails::Engine
 
     config.to_prepare do
-      require "polymorphic/attachment"
-      require "ffcrm_attachments/attachment_hook"
+      require 'polymorphic/attachment'
+      require 'ffcrm_attachments/attachment_hook'
+      require 'ffcrm_attachments/ability'
 
       ActiveSupport.on_load(:fat_free_crm_attachment) do
-
         ENTITIES.each do |entity|
           entity.safe_constantize.class_eval do
             has_many :attachments, as: :entity, dependent: :destroy
@@ -14,7 +14,10 @@ module FfcrmAttachments
               allow_destroy: true, reject_if: lambda { |l| l[:attachment].blank? }
           end
         end
+      end
 
+      ActiveSupport.on_load(:fat_free_crm_ability) do
+        self.send(:prepend, FfcrmAttachments::Ability)
       end
     end
 


### PR DESCRIPTION
This patch will allow non-admin users to download attachments.
Up until now only admins had the correct CanCanCan abilities set.